### PR TITLE
Move lodash from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "asyncbox": "^2.3.1",
     "babel-runtime": "=5.8.24",
     "source-map-support": "^0.2.8",
-    "teen_process": "^1.3.1"
+    "teen_process": "^1.3.1",
+    "lodash": "^3.10.1"
   },
   "scripts": {
     "prepublish": "$(npm bin)/gulp prepublish",
@@ -39,7 +40,6 @@
   "devDependencies": {
     "appium-gulp-plugins": "^1.3.11",
     "chai": "^3.2.0",
-    "gulp": "^3.9.0",
-    "lodash": "^3.10.1"
+    "gulp": "^3.9.0"
   }
 }


### PR DESCRIPTION
Lodash is imported in `lib/simctl.js` and thus we need to move it from `devDependencies` to `dependencies`. 